### PR TITLE
Adds py_modules attr to setup() args, with yturl modules as value

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
     author = "Chris Down",
     author_email = "chris@chrisdown.name",
 
+    py_modules = ["yturl"],
     scripts = [ "yturl" ],
 
     classifiers = [


### PR DESCRIPTION
So running ``python setup.py install`` would install ``yturl`` module as well
as installing the runner script.